### PR TITLE
Deprecation warning in ggplot, and remove unneeded dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: NormalyzerDE
 Title: Evaluation of normalization methods and calculation of differential expression analysis statistics
-Version: 1.20.0
+Version: 1.23.1
 Author: Jakob Willforss
 Authors@R: c(
     person("Jakob", "Willforss", email="jakob.willforss@hotmail.com", role=c("aut", "cre")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: NormalyzerDE
 Title: Evaluation of normalization methods and calculation of differential expression analysis statistics
-Version: 1.19.7
+Version: 1.20.0
 Author: Jakob Willforss
 Authors@R: c(
     person("Jakob", "Willforss", email="jakob.willforss@hotmail.com", role=c("aut", "cre")),
@@ -21,7 +21,6 @@ Imports:
     car,
     ggplot2,
     methods,
-    Biobase,
     utils,
     stats,
     SummarizedExperiment,

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,9 @@
+CHANGES IN VERSION 1.23.1
+----------------------------------
+
+* Remove unnecessary dependency (Biobase) by calling rowMedians with matrixStats::rowMedians instead
+* Fix deprecation warning by using guide = "none" instead of FALSE
+
 CHANGES IN VERSION 1.19.7
 ----------------------------------
 

--- a/R/analyzeResults.R
+++ b/R/analyzeResults.R
@@ -33,6 +33,7 @@ analyzeNormalizations <- function(nr, categoricalAnova=FALSE) {
 #' @return avgCVPerNormAndReplicates Matrix with group CVs as rows and
 #'   normalization technique as columns
 #' @keywords internal
+#' @export
 calculateReplicateCV <- function(methodList, sampleReplicateGroups) {
     
     calculateFeatureCVs <- function(feature, groups) {
@@ -99,6 +100,7 @@ calculateReplicateCV <- function(methodList, sampleReplicateGroups) {
 #' @return methodFeatureCVMatrix Matrix with feature as rows and normalization
 #'   method as columns
 #' @keywords internal
+#' @export
 calculateFeatureCV <- function(methodList) {
     
     methodCount <- length(methodList)
@@ -131,6 +133,7 @@ calculateFeatureCV <- function(methodList) {
 #' @param sampleReplicateGroups Condition header.
 #' @return condAvgMadMat Matrix with average MAD for each biological condition.
 #' @keywords internal
+#' @export
 calculateAvgMadMem <- function(methodList, sampleReplicateGroups) {
     
     groupIndexList <- getIndexList(sampleReplicateGroups)
@@ -174,6 +177,7 @@ calculateAvgMadMem <- function(methodList, sampleReplicateGroups) {
 #' @return avgVarianceMat Matrix with average variance for each biological
 #' condition
 #' @keywords internal
+#' @export
 calculateAvgReplicateVariation <- function(methodList, sampleReplicateGroups) {
 
     groupIndexList <- getIndexList(sampleReplicateGroups)
@@ -217,6 +221,7 @@ calculateAvgReplicateVariation <- function(methodList, sampleReplicateGroups) {
 #' @return avgCorSum Matrix with column corresponding to normalization
 #' approaches and rows corresponding to replicate group
 #' @keywords internal
+#' @export
 calculateSummarizedCorrelationVector <- function(
     methodlist, allReplicateGroups, sampleGroupsWithReplicates, corrType) {
     
@@ -260,6 +265,7 @@ calculateSummarizedCorrelationVector <- function(
 #' @param corrType Type of correlation (Pearson or Spearman)
 #' @return corSums
 #' @keywords internal
+#' @export
 calculateCorrSum <- function(methodData, allReplicateGroups, 
                              sampleGroupsWithReplicates, corrType) {
     
@@ -296,6 +302,7 @@ calculateCorrSum <- function(methodData, allReplicateGroups,
 #' @return avgVarianceMat Matrix with average variance for each biological
 #' condition
 #' @keywords internal
+#' @export
 calculateANOVAPValues <- function(methodList, 
                                   sampleReplicateGroups, 
                                   categoricalANOVA) {

--- a/R/analyzeResults.R
+++ b/R/analyzeResults.R
@@ -33,7 +33,6 @@ analyzeNormalizations <- function(nr, categoricalAnova=FALSE) {
 #' @return avgCVPerNormAndReplicates Matrix with group CVs as rows and
 #'   normalization technique as columns
 #' @keywords internal
-#' @export
 calculateReplicateCV <- function(methodList, sampleReplicateGroups) {
     
     calculateFeatureCVs <- function(feature, groups) {
@@ -100,7 +99,6 @@ calculateReplicateCV <- function(methodList, sampleReplicateGroups) {
 #' @return methodFeatureCVMatrix Matrix with feature as rows and normalization
 #'   method as columns
 #' @keywords internal
-#' @export
 calculateFeatureCV <- function(methodList) {
     
     methodCount <- length(methodList)
@@ -133,7 +131,6 @@ calculateFeatureCV <- function(methodList) {
 #' @param sampleReplicateGroups Condition header.
 #' @return condAvgMadMat Matrix with average MAD for each biological condition.
 #' @keywords internal
-#' @export
 calculateAvgMadMem <- function(methodList, sampleReplicateGroups) {
     
     groupIndexList <- getIndexList(sampleReplicateGroups)
@@ -177,7 +174,6 @@ calculateAvgMadMem <- function(methodList, sampleReplicateGroups) {
 #' @return avgVarianceMat Matrix with average variance for each biological
 #' condition
 #' @keywords internal
-#' @export
 calculateAvgReplicateVariation <- function(methodList, sampleReplicateGroups) {
 
     groupIndexList <- getIndexList(sampleReplicateGroups)
@@ -221,7 +217,6 @@ calculateAvgReplicateVariation <- function(methodList, sampleReplicateGroups) {
 #' @return avgCorSum Matrix with column corresponding to normalization
 #' approaches and rows corresponding to replicate group
 #' @keywords internal
-#' @export
 calculateSummarizedCorrelationVector <- function(
     methodlist, allReplicateGroups, sampleGroupsWithReplicates, corrType) {
     
@@ -265,7 +260,6 @@ calculateSummarizedCorrelationVector <- function(
 #' @param corrType Type of correlation (Pearson or Spearman)
 #' @return corSums
 #' @keywords internal
-#' @export
 calculateCorrSum <- function(methodData, allReplicateGroups, 
                              sampleGroupsWithReplicates, corrType) {
     
@@ -302,7 +296,6 @@ calculateCorrSum <- function(methodData, allReplicateGroups,
 #' @return avgVarianceMat Matrix with average variance for each biological
 #' condition
 #' @keywords internal
-#' @export
 calculateANOVAPValues <- function(methodList, 
                                   sampleReplicateGroups, 
                                   categoricalANOVA) {

--- a/R/calculateStatistics.R
+++ b/R/calculateStatistics.R
@@ -312,7 +312,7 @@ plotComparisonVenns <- function(nst, jobName, currentLayout, pageno,
                 ggplot2::theme_void() +
                 ggplot2::theme(legend.position = 'bottom', legend.direction='vertical') +
                 ggplot2::scale_fill_manual(values = c('cornflowerblue', 'firebrick',  'gold')) +
-                ggplot2::scale_colour_manual(values = c('cornflowerblue', 'firebrick', 'gold'), guide = FALSE) +
+                ggplot2::scale_colour_manual(values = c('cornflowerblue', 'firebrick', 'gold'), guide = "none") +
                 ggplot2::labs(fill = NULL) +
                 ggplot2::annotate("text", x = df.vdc$x, y = df.vdc$y, label = df.vdc$label, size = 5) +
                 ggplot2::ggtitle(paste0(sigThresType, " < ", sigThres, 

--- a/R/generatePlots.R
+++ b/R/generatePlots.R
@@ -936,7 +936,7 @@ plotRLE <- function(nr, currentLayout, pageno) {
     graphics::par(mar=c(2, 2, 2, 1), oma=c(3, 2, 3, 2), xpd=NA)
     
     for (i in seq_along(methodlist)) {
-        deviations = methodlist[[i]] - Biobase::rowMedians(methodlist[[i]], na.rm=TRUE)
+        deviations = methodlist[[i]] - matrixStats::rowMedians(methodlist[[i]], na.rm=TRUE)
         graphics::boxplot(
             deviations, 
             outcol="lightgray", 


### PR DESCRIPTION
The title says it. Fixing a deprecation warning and removing an unneeded dependency by swapping to matrixStats::rowMedians.

Close #37 
Close #34 