### PR TITLE
Categorical anova used when analyzing normalizations directly

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: NormalyzerDE
 Title: Evaluation of normalization methods and calculation of differential expression analysis statistics
-Version: 1.23.1
+Version: 1.23.2
 Author: Jakob Willforss
 Authors@R: c(
     person("Jakob", "Willforss", email="jakob.willforss@hotmail.com", role=c("aut", "cre")),

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,8 @@
+CHANGES IN VERSION 1.23.2
+----------------------------------
+
+* Fix bug where non-categorical ANOVA setting wasn't applied
+
 CHANGES IN VERSION 1.23.1
 ----------------------------------
 

--- a/R/NormalyzerEvaluationResults.R
+++ b/R/NormalyzerEvaluationResults.R
@@ -45,6 +45,7 @@ NormalyzerEvaluationResults <- setClass("NormalyzerEvaluationResults",
 #' Constructor for NormalyzerEvaluationResults
 #' 
 #' @param nr NormalyzerResults object
+#' @param categoricalAnova Should ANOVA be categorical or not
 #' @return nds Generated NormalyzerEvaluationResults instance
 #' @export
 #' @examples
@@ -52,7 +53,7 @@ NormalyzerEvaluationResults <- setClass("NormalyzerEvaluationResults",
 #' normObj <- getVerifiedNormalyzerObject("job_name", example_summarized_experiment)
 #' normResults <- normMethods(normObj)
 #' normEval <- NormalyzerEvaluationResults(normResults)
-NormalyzerEvaluationResults <- function (nr) {
+NormalyzerEvaluationResults <- function (nr, categoricalAnova=TRUE) {
 
                nds <- nds(nr)
                sampleReplicateGroups <- sampleReplicateGroups(nds) 
@@ -80,7 +81,7 @@ NormalyzerEvaluationResults <- function (nr) {
                    avgvarmempdiff <- calculatePercentageAvgDiffInMat(avgVarianceMat)
                    
                    # Significance measures
-                   anovaPValsWithNAMat <- calculateANOVAPValues(methodList, sampleReplicateGroups, categoricalANOVA=TRUE)
+                   anovaPValsWithNAMat <- calculateANOVAPValues(methodList, sampleReplicateGroups, categoricalANOVA=categoricalAnova)
                    validPValuesContrast <- !is.na(anovaPValsWithNAMat[, 1])
                    
                    log2AnovaFDR <- rep(NA, length(anovaPValsWithNAMat[, 1]))

--- a/R/analyzeResults.R
+++ b/R/analyzeResults.R
@@ -17,7 +17,7 @@
 #' normResultsWithEval <- analyzeNormalizations(normResults)
 analyzeNormalizations <- function(nr, categoricalAnova=FALSE) {
 
-    ner <- NormalyzerEvaluationResults(nr)
+    ner <- NormalyzerEvaluationResults(nr, categoricalAnova)
     ner(nr) <- ner
     
     nr


### PR DESCRIPTION
Close #31 

When following the vignette, it is demonstrated how one can analyze normalizations directly.

Here is a parameter which allow the user to use numerical or categorical ANOVA (this is for an evaluation chart only, not for the later statistical analysis).

This parameter did not change the ANOVA call, which always was performed as categorical.

This PR updates such that the setting is used.